### PR TITLE
Replace hardcoded file separators

### DIFF
--- a/ByteStorm.pde
+++ b/ByteStorm.pde
@@ -45,7 +45,7 @@ void setup() {
   noStroke();
   noLoop();
   
-  boolean read = readFile(GameSettings.FOLDERNAME + "/" + GameSettings.FILENAME);
+  boolean read = readFile(GameSettings.FOLDERNAME + File.separator + GameSettings.FILENAME);
   
   difficultyMultiplier = GameSettings.decodeDifficulty(GameSettings.DIFFICULTY);
     


### PR DESCRIPTION
Replaces  '/' used as file separators with the platform-dependent File.separator system property
Makes code portable to other platforms